### PR TITLE
fix:多个请求并发导致loading不会关闭

### DIFF
--- a/src/plugins/axios/Axios.ts
+++ b/src/plugins/axios/Axios.ts
@@ -33,7 +33,7 @@ export default class Axios {
   private interceptorsRequest() {
     this.instance.interceptors.request.use(
       (config: AxiosRequestConfig) => {
-        this.loading = ElLoading.service({
+        this.loading = this.loading ?? ElLoading.service({
           background: 'rgba(255,255,255,0.1)',
         })
         errorStore().resetError()


### PR DESCRIPTION
两个请求以上并发，会导致第一个loading被覆盖，从而关不掉，改成单例以修复此问题